### PR TITLE
don't trigger hover on touch devices

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -99,9 +99,11 @@ a {
   border-bottom: 1px dashed;
   color: initial;
 }
-:not(.logo) > a:hover {
-  position: relative;
-  inset: 1px 0 0 1px;
+@media (hover: hover) and (pointer: fine) {
+  :not(.logo) > a:hover {
+    position: relative;
+    inset: 1px 0 0 1px;
+  }
 }
 nav a, footer a, .archive a, sup a {
   border-bottom: none;


### PR DESCRIPTION
Reference:

>  Because the :hover CSS does not make sense, and it can even be disturbing if a tablet triggers it on click/tap because then it might stick until the element loses focus.
>
> — https://stackoverflow.com/questions/23885255/how-to-remove-ignore-hover-css-style-on-touch-devices